### PR TITLE
Mod Support: RemoteTech Redev Antennas

### DIFF
--- a/GameData/ProbesBeforeCrew/Mod Support/ZsRemoteTechAntennasPatch.cfg
+++ b/GameData/ProbesBeforeCrew/Mod Support/ZsRemoteTechAntennasPatch.cfg
@@ -1,7 +1,7 @@
 // Probes Before Crew RemoteTech Redev Antennas Patch
 
 /////////// RemoteTech
-@PART[RTLongAntenna2]:AFTER[RemoteTech]:NEEDS[CommunityTechTree]  // Comm 32   5 mil
+@PART[RTLongAntenna2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // Comm 32   5 mil
 {
 	@TechRequired = largeElectrics
 	@entryCost = 12000
@@ -34,7 +34,7 @@
 	}
 }
 
-@PART[RTLongDish2]:AFTER[RemoteTech]:NEEDS[CommunityTechTree]  // KR-14  60 Bil
+@PART[RTLongDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // KR-14  60 Bil
 {
 	@TechRequired = highTechElectricalSystems
 	@entryCost = 42500
@@ -45,7 +45,7 @@
 	}
 }
 
-@PART[RTGigaDish2]:AFTER[RemoteTech]:NEEDS[CommunityTechTree]  // CommTech-1   350 Bil
+@PART[RTGigaDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // CommTech-1   350 Bil
 {
 	@TechRequired = highPowerElectricalSystems
 	@entryCost = 76500
@@ -56,7 +56,7 @@
 	}
 }
 
-@PART[RTGigaDish1]:AFTER[RemoteTech]:NEEDS[CommunityTechTree]  // GX-128   400 Bil
+@PART[RTGigaDish1]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // GX-128   400 Bil
 {
 	@TechRequired = experimentalElectricalSystems
 	@entryCost = 97500

--- a/GameData/ProbesBeforeCrew/Mod Support/ZsRemoteTechAntennasPatch.cfg
+++ b/GameData/ProbesBeforeCrew/Mod Support/ZsRemoteTechAntennasPatch.cfg
@@ -1,36 +1,36 @@
 // Probes Before Crew RemoteTech Redev Antennas Patch
 
 /////////// RemoteTech
-@PART[RTLongAntenna2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // Comm 32   5 mil
-{
-	@TechRequired = largeElectrics
-	@entryCost = 12000
-	@cost = 1500
-	@MODULE[ModuleDataTransmitter]
-	{
-		@antennaPower = 5000000
-	}
-}
-
-@PART[RTLongAntenna3]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // EXP-VR-2T  3 mil
+@PART[RTLongAntenna3]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // EXP-VR-2T  2 Bil Direct
 {
 	@TechRequired = electrics
 	@entryCost = 3400
 	@cost = 550
 	@MODULE[ModuleDataTransmitter]
 	{
-		@antennaPower = 3000000
+		@antennaPower = 2000000000
 	}
 }
 
-@PART[RTShortDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // KR-7   90 mil
+@PART[RTShortDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // KR-7   70 mil Relay
 {
 	@TechRequired = electrics
 	@entryCost = 3800
 	@cost = 800
 	@MODULE[ModuleDataTransmitter]
 	{
-		@antennaPower = 90000000
+		@antennaPower = 70000000
+	}
+}
+
+@PART[RTLongAntenna2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // Comm 32   1 Bil Direct
+{
+	@TechRequired = largeElectrics
+	@entryCost = 12000
+	@cost = 1500
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 1000000000
 	}
 }
 

--- a/GameData/ProbesBeforeCrew/Mod Support/ZsRemoteTechAntennasPatch.cfg
+++ b/GameData/ProbesBeforeCrew/Mod Support/ZsRemoteTechAntennasPatch.cfg
@@ -1,54 +1,71 @@
 // Probes Before Crew RemoteTech Redev Antennas Patch
-// These are the same patches as the ones described in ZsRemoteTechPatch, only the mod that it is applied to is changed.
 
 /////////// RemoteTech
-
-@PART[RTLongAntenna2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // Comm 32   2 mil
+@PART[RTLongAntenna2]:AFTER[RemoteTech]:NEEDS[CommunityTechTree]  // Comm 32   5 mil
 {
 	@TechRequired = largeElectrics
 	@entryCost = 12000
 	@cost = 1500
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 5000000
+	}
 }
 
-@PART[RTLongAntenna3]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // EXP-VR-2T  800k
+@PART[RTLongAntenna3]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // EXP-VR-2T  3 mil
 {
 	@TechRequired = electrics
 	@entryCost = 3400
 	@cost = 550
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 3000000
+	}
 }
 
-@PART[RTShortDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // KR-7   4 Bil
+@PART[RTShortDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // KR-7   90 mil
 {
 	@TechRequired = electrics
 	@entryCost = 3800
 	@cost = 800
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 90000000
+	}
 }
 
-@PART[RTLongDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // KR-14  50 Bil
+@PART[RTLongDish2]:AFTER[RemoteTech]:NEEDS[CommunityTechTree]  // KR-14  60 Bil
 {
 	@TechRequired = highTechElectricalSystems
 	@entryCost = 42500
 	@cost = 4500
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 60000000000
+	}
 }
 
-@PART[RTGigaDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // CommTech-1   200 Bil
+@PART[RTGigaDish2]:AFTER[RemoteTech]:NEEDS[CommunityTechTree]  // CommTech-1   350 Bil
 {
 	@TechRequired = highPowerElectricalSystems
 	@entryCost = 76500
 	@cost = 9500
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 350000000000
+	}
 }
 
-@PART[RTGigaDish1]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // GX-128   300 Bil
+@PART[RTGigaDish1]:AFTER[RemoteTech]:NEEDS[CommunityTechTree]  // GX-128   400 Bil
 {
 	@TechRequired = experimentalElectricalSystems
 	@entryCost = 97500
 	@cost = 13000
+	@MODULE[ModuleDataTransmitter]
+	{
+		@antennaPower = 400000000000
+	}
 }
-
-
-
-
-
 
 
 

--- a/GameData/ProbesBeforeCrew/Mod Support/ZsRemoteTechAntennasPatch.cfg
+++ b/GameData/ProbesBeforeCrew/Mod Support/ZsRemoteTechAntennasPatch.cfg
@@ -1,0 +1,66 @@
+// Probes Before Crew RemoteTech Redev Antennas Patch
+// These are the same patches as the ones described in ZsRemoteTechPatch, only the mod that it is applied to is changed.
+
+/////////// RemoteTech
+
+@PART[RTShortAntenna1]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // DP-10  500k
+{
+	@TechRequired = start
+	@entryCost = 200
+	@cost = 120
+}
+
+@PART[RTLongAntenna2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // Comm 32   5 mil
+{
+	@TechRequired = largeElectrics
+	@entryCost = 12000
+	@cost = 1500
+}
+
+@PART[RTLongAntenna3]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // EXP-VR-2T  3 mil
+{
+	@TechRequired = electrics
+	@entryCost = 3400
+	@cost = 550
+}
+
+@PART[RTShortDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // KR-7   90 mil
+{
+	@TechRequired = electrics
+	@entryCost = 3800
+	@cost = 800
+}
+
+@PART[RTLongDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // KR-14  60 Bil
+{
+	@TechRequired = highTechElectricalSystems
+	@entryCost = 42500
+	@cost = 4500
+}
+
+@PART[RTGigaDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // CommTech-1   350 Bil
+{
+	@TechRequired = highPowerElectricalSystems
+	@entryCost = 76500
+	@cost = 9500
+}
+
+@PART[RTGigaDish1]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // GX-128   400 Bil
+{
+	@TechRequired = experimentalElectricalSystems
+	@entryCost = 97500
+	@cost = 13000
+}
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/GameData/ProbesBeforeCrew/Mod Support/ZsRemoteTechAntennasPatch.cfg
+++ b/GameData/ProbesBeforeCrew/Mod Support/ZsRemoteTechAntennasPatch.cfg
@@ -3,49 +3,42 @@
 
 /////////// RemoteTech
 
-@PART[RTShortAntenna1]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // DP-10  500k
-{
-	@TechRequired = start
-	@entryCost = 200
-	@cost = 120
-}
-
-@PART[RTLongAntenna2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // Comm 32   5 mil
+@PART[RTLongAntenna2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // Comm 32   2 mil
 {
 	@TechRequired = largeElectrics
 	@entryCost = 12000
 	@cost = 1500
 }
 
-@PART[RTLongAntenna3]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // EXP-VR-2T  3 mil
+@PART[RTLongAntenna3]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // EXP-VR-2T  800k
 {
 	@TechRequired = electrics
 	@entryCost = 3400
 	@cost = 550
 }
 
-@PART[RTShortDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // KR-7   90 mil
+@PART[RTShortDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // KR-7   4 Bil
 {
 	@TechRequired = electrics
 	@entryCost = 3800
 	@cost = 800
 }
 
-@PART[RTLongDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // KR-14  60 Bil
+@PART[RTLongDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // KR-14  50 Bil
 {
 	@TechRequired = highTechElectricalSystems
 	@entryCost = 42500
 	@cost = 4500
 }
 
-@PART[RTGigaDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // CommTech-1   350 Bil
+@PART[RTGigaDish2]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // CommTech-1   200 Bil
 {
 	@TechRequired = highPowerElectricalSystems
 	@entryCost = 76500
 	@cost = 9500
 }
 
-@PART[RTGigaDish1]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // GX-128   400 Bil
+@PART[RTGigaDish1]:AFTER[RemoteTech-Antennas]:NEEDS[CommunityTechTree]  // GX-128   300 Bil
 {
 	@TechRequired = experimentalElectricalSystems
 	@entryCost = 97500


### PR DESCRIPTION
Simple patch copying from the existing RemoteTech patch files, these should be tested and further balanced before merging.

Resolves #3 