### PR TITLE
RestockPlus science fix.

### DIFF
--- a/GameData/ProbesBeforeCrew/Mod Support/ZsRestockPlusPatch.cfg
+++ b/GameData/ProbesBeforeCrew/Mod Support/ZsRestockPlusPatch.cfg
@@ -436,6 +436,25 @@
 }
 
 
+//// ***************** Science
+
+@PART[restock-materialbay-radial-1]:AFTER[ReStockPlus]:NEEDS[CommunityTechTree] // Radial Science Jr.
+{
+	@MODULE[ModuleScienceExperiment]
+	{
+		@xmitDataScalar = 0.3
+	}
+}
+
+@PART[restock-goocanister-625-1]:AFTER[ReStockPlus]:NEEDS[CommunityTechTree] // Inline Mystery Goo
+{
+	@MODULE[ModuleScienceExperiment]
+	{
+		@xmitDataScalar = 0.3
+	}
+}
+
+
 //// ***************** Structural
 
 @PART[restock-truss-3]:AFTER[ReStockPlus]:NEEDS[CommunityTechTree] // XXL Modular Girder Segment


### PR DESCRIPTION
Update radial Science Jr. and inline Mystery Goo behavior to match stock patches.