### PR TITLE
Tweaked 1.875m drone core.

### DIFF
--- a/GameData/ProbesBeforeCrew/Mod Support/ZsRestockPlusPatch.cfg
+++ b/GameData/ProbesBeforeCrew/Mod Support/ZsRestockPlusPatch.cfg
@@ -72,12 +72,12 @@
 @PART[restock-drone-core-1875-1]:AFTER[ReStockPlus]:NEEDS[CommunityTechTree] // 1.875m Drone Core
 {
 	@TechRequired = advUnmanned
-	// @entryCost = 19000
-	// @cost = 2900
+	@entryCost = 35000
+	@cost = 3150
 	@RESOURCE[ElectricCharge]
 	{
-		@amount = 2000
-		@maxAmount = 2000
+		@amount = 1750
+		@maxAmount = 1750
 	}
 }
 


### PR DESCRIPTION
Tweaked 1.875m drone core behavior to match existing Missing History configs for an equivalent part.