### PR TITLE
Update ZsMissingHistoryPatch.cfg

### DIFF
--- a/GameData/ProbesBeforeCrew/Mod Support/ZsMissingHistoryPatch.cfg
+++ b/GameData/ProbesBeforeCrew/Mod Support/ZsMissingHistoryPatch.cfg
@@ -1,5 +1,5 @@
 // Zee's Probes Before Crew MissingHistory Patch
-// Version 3.0.0-beta2
+// Version 3.0.0
 
 /////////// Missing History
 


### PR DESCRIPTION
restored Missing History 2k battery when Restock+ is present, as it is technically a different part. It is a different mass and charge capacity. And most importantly, the Restock battery has very annoying surface attach mesh that tilts objects.