### PR TITLE
Move TS-06 separator again, this time hopefully for good.

### DIFF
--- a/GameData/ProbesBeforeCrew/_Core/Zs_ProbesBeforeCrew.cfg
+++ b/GameData/ProbesBeforeCrew/_Core/Zs_ProbesBeforeCrew.cfg
@@ -811,7 +811,7 @@ EXPERIMENT_DEFINITION
 
 @PART[Separator_0]:NEEDS[CommunityTechTree]:FOR[ProbesBeforeCrew]
 {
-	@TechRequired = advRocketry
+	@TechRequired = generalConstruction
 }
 
 @PART[Decoupler_1]:NEEDS[CommunityTechTree]:FOR[ProbesBeforeCrew]


### PR DESCRIPTION
Now in General Construction (same tier as Advanced Rocketry) in order to match TS-12 separator.