### PR TITLE
Move EVA chute to Aviation.

### DIFF
--- a/GameData/ProbesBeforeCrew/_Core/Zs_ProbesBeforeCrew.cfg
+++ b/GameData/ProbesBeforeCrew/_Core/Zs_ProbesBeforeCrew.cfg
@@ -639,7 +639,7 @@ EXPERIMENT_DEFINITION
 
 @PART[evaChute]:NEEDS[CommunityTechTree]:FOR[ProbesBeforeCrew] 
 {
-	@TechRequired = simpleCommandModules
+	@TechRequired = aviation
 }
 
 @PART[evaJetpack]:NEEDS[CommunityTechTree]:FOR[ProbesBeforeCrew] 


### PR DESCRIPTION
Now placed with the Mk1 Cockpit instead of the Mk1 Command Pod. You get more utility out of it doing airplane things, and Aviation is a tier earlier than Simple Command Modules. Jetpack gets to stay where it is since it's a space thing.