### PR TITLE
Added entry costs for EVA chute and jetpack.

### DIFF
--- a/GameData/ProbesBeforeCrew/_Core/Zs_ProbesBeforeCrew.cfg
+++ b/GameData/ProbesBeforeCrew/_Core/Zs_ProbesBeforeCrew.cfg
@@ -640,11 +640,15 @@ EXPERIMENT_DEFINITION
 @PART[evaChute]:NEEDS[CommunityTechTree]:FOR[ProbesBeforeCrew] 
 {
 	@TechRequired = aviation
+	@entryCost = 100
+	@cost = 10
 }
 
 @PART[evaJetpack]:NEEDS[CommunityTechTree]:FOR[ProbesBeforeCrew] 
 {
 	@TechRequired = simpleCommandModules
+	@entryCost = 100
+	@cost = 25
 }
 
 


### PR DESCRIPTION
Small enough to not actually act as a significant barrier to entry, just there for consistency reasons.