### PR TITLE
Move Small Hardpoint to match Structural Pylon.

### DIFF
--- a/GameData/ProbesBeforeCrew/_Core/Zs_ProbesBeforeCrew.cfg
+++ b/GameData/ProbesBeforeCrew/_Core/Zs_ProbesBeforeCrew.cfg
@@ -986,6 +986,16 @@ EXPERIMENT_DEFINITION
 	@TechRequired = specializedConstruction
 }
 
+@PART[smallHardpoint]:NEEDS[CommunityTechTree]:FOR[ProbesBeforeCrew]
+{
+	@TechRequired = supersonicFlight
+}
+
+@PART[structuralPylon]:NEEDS[CommunityTechTree]:FOR[ProbesBeforeCrew]
+{
+	@TechRequired = highAltitudeFlight
+}
+
 @PART[trussPiece1x]:NEEDS[CommunityTechTree]:FOR[ProbesBeforeCrew]
 {
 	@cost = 50


### PR DESCRIPTION
Absolutely inconsequential, but it bugs me that the Small Hardpoint isn't in the same branch as the Structural Pylon, despite one just being a larger version of the other. Small Hardpoint now comes one node before Structural Pylon, and Structural Pylon has been locked into its stock placement for posterity.