### PR TITLE
Revert SPER telescope patch, tweak science value.

### DIFF
--- a/GameData/ProbesBeforeCrew/Mod Support/ZsStationPartsXRPatch.cfg
+++ b/GameData/ProbesBeforeCrew/Mod Support/ZsStationPartsXRPatch.cfg
@@ -695,11 +695,11 @@
 //// ***************** Experiment Definitions 
 
 
-// This adds SPER visual scan experiment to stock, missing SPER 2.5m cupola, small and large USI-LS cupolas, SPER telescope.
+// This adds SPER visual scan experiment to stock, missing SPER 2.5m cupola, small and large USI-LS cupolas.
 
-@PART[cupola|sspx-observation-25-1|USILS_SmCupola|USILS_ViewingCupola|sspx-cupola-telescope-125-1]:NEEDS[CommunityTechTree,StationPartsExpansionRedux]
+@PART[cupola|sspx-observation-25-1|USILS_SmCupola|USILS_ViewingCupola]:NEEDS[CommunityTechTree,StationPartsExpansionRedux]
 {
-	!MODULE[ModuleScienceExperiment]:HAS[#experimentID[crewReport|sspxTelescopeObservation]] {}
+	!MODULE[ModuleScienceExperiment]:HAS[#experimentID[crewReport]] {}
 	%MODULE[ModuleScienceExperiment]
 	{
 		name = ModuleScienceExperiment
@@ -737,6 +737,14 @@
 {
 	@baseValue = 8
 	@scienceCap = 8
+	@situationMask = 49
+	@biomeMask = 0
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[sspxTelescopeObservation]]:AFTER[StationPartsExpansionRedux]:NEEDS[CommunityTechTree]
+{
+	@baseValue = 3
+	@scienceCap = 3
 	@situationMask = 49
 	@biomeMask = 0
 }


### PR DESCRIPTION
The visual observation experiment wasn't working with the SPER telescope since it requires a crew member and the telescope has no crew slot. Now uses its own experiment again, but with a much lower science value than before to avoid imbalance.