### PR TITLE
Remove visual observation from small USI cupola.

### DIFF
--- a/GameData/ProbesBeforeCrew/Mod Support/ZsStationPartsXRPatch.cfg
+++ b/GameData/ProbesBeforeCrew/Mod Support/ZsStationPartsXRPatch.cfg
@@ -695,9 +695,9 @@
 //// ***************** Experiment Definitions 
 
 
-// This adds SPER visual scan experiment to stock, missing SPER 2.5m cupola, small and large USI-LS cupolas.
+// This adds SPER visual scan experiment to stock, missing SPER 2.5m cupola, large USI-LS cupola.
 
-@PART[cupola|sspx-observation-25-1|USILS_SmCupola|USILS_ViewingCupola]:NEEDS[CommunityTechTree,StationPartsExpansionRedux]
+@PART[cupola|sspx-observation-25-1|USILS_ViewingCupola]:NEEDS[CommunityTechTree,StationPartsExpansionRedux]
 {
 	!MODULE[ModuleScienceExperiment]:HAS[#experimentID[crewReport]] {}
 	%MODULE[ModuleScienceExperiment]


### PR DESCRIPTION
The experiment requires a crew member and the small cupola holds no crew, so it didn't work anyway.